### PR TITLE
Renamed parameter application_id to client_id.

### DIFF
--- a/tsumugi_bot.rb
+++ b/tsumugi_bot.rb
@@ -6,7 +6,7 @@ require_relative './lib/custom_commands_generator'
 require_relative './lib/custom_commands'
 Dotenv.load
 
-bot = Discordrb::Commands::CommandBot.new token: ENV['TOKEN'], application_id: ENV['APPID'], prefix: '!'
+bot = Discordrb::Commands::CommandBot.new token: ENV['TOKEN'], client_id: ENV['APPID'], prefix: '!'
 bot.include! RaidCommands
 bot.include! Messages
 


### PR DESCRIPTION
discordrb updated renamed application_id to client_id, so it needed to be changed.
